### PR TITLE
Feat/login : 로그인 / 회원가입 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## Secrets Managing ###
+src/main/resources/env.yml
+src/main/resources/application-*.yml
+!src/main/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    implementation 'org.springframework.session:spring-session-jdbc'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,17 +28,35 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'mysql:mysql-connector-java:8.0.33'
+
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jwts
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'
+
+    // gson
+    implementation 'com.google.code.gson:gson'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+bootJar {
+    enabled = true
+}
+
+jar {
+    enabled = false
 }

--- a/src/main/java/com/generic/typed/config/AuthenticationManagerConfig.java
+++ b/src/main/java/com/generic/typed/config/AuthenticationManagerConfig.java
@@ -1,0 +1,30 @@
+package com.generic.typed.config;
+
+import com.generic.typed.security.jwt.filter.JwtAuthenticationFilter;
+import com.generic.typed.security.jwt.provider.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthenticationManagerConfig extends AbstractHttpConfigurer<AuthenticationManagerConfig, HttpSecurity> {
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Override
+    public void configure(HttpSecurity builder) throws Exception {
+        AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+
+        builder.addFilterBefore(
+                        new JwtAuthenticationFilter(authenticationManager),
+                        UsernamePasswordAuthenticationFilter.class)
+                .authenticationProvider(jwtAuthenticationProvider);
+    }
+
+
+
+}

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -49,4 +49,20 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .build();
     }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        UserDetails user = User.withUsername("hyein")
+                .password("1234")
+                .roles("ADMIN")
+                .build();
+        manager.createUser(user);
+        return manager;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
 }

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.generic.typed.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers("/favicon.ico")
+                .requestMatchers("/error")
+                .requestMatchers(toH2Console());
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/auth/login").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+}

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -1,17 +1,26 @@
 package com.generic.typed.config;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.jaas.memory.InMemoryConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 @Configuration
-@EnableWebSecurity
+// TODO : 배포하기전에 debug 모드 false로 변경
+@EnableWebSecurity(debug = true)
 public class SecurityConfig {
 
     @Bean
@@ -29,6 +38,14 @@ public class SecurityConfig {
                         .requestMatchers("/auth/login").permitAll()
                         .anyRequest().authenticated()
                 )
+                .formLogin(formLogin -> formLogin
+                        .loginPage("/auth/login")
+                        .loginProcessingUrl("/auth/login")
+                        .usernameParameter("username")
+                        .passwordParameter("password")
+                        .defaultSuccessUrl("/")
+                )
+                .userDetailsService(userDetailsService())
                 .csrf(AbstractHttpConfigurer::disable)
                 .build();
     }

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -45,6 +45,10 @@ public class SecurityConfig {
                         .passwordParameter("password")
                         .defaultSuccessUrl("/")
                 )
+                .rememberMe(rm -> rm.rememberMeParameter("remember")
+                        .alwaysRemember(false)
+                        .tokenValiditySeconds(2592000)
+                )
                 .userDetailsService(userDetailsService())
                 .csrf(AbstractHttpConfigurer::disable)
                 .build();

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -1,72 +1,53 @@
 package com.generic.typed.config;
 
-import jakarta.persistence.criteria.CriteriaBuilder;
+import com.generic.typed.security.jwt.exception.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.jaas.memory.InMemoryConfiguration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+import org.springframework.web.cors.CorsUtils;
 
 @Configuration
-// TODO : 배포하기전에 debug 모드 false로 변경
-@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers("/favicon.ico")
-                .requestMatchers("/error")
-                .requestMatchers(toH2Console());
-    }
+    private final AuthenticationManagerConfig authenticationManagerConfig;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/auth/login").permitAll()
-                        .anyRequest().authenticated()
+                .sessionManagement(httpSecuritySessionManagementConfigure -> httpSecuritySessionManagementConfigure.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(FormLoginConfigurer::disable)
+                .csrf(CsrfConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .httpBasic(HttpBasicConfigurer::disable)
+                .authorizeHttpRequests(httpRequest -> httpRequest
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("/members/signup", "/members/login", "/members/refreshToken").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/categories/**").permitAll()
+                        .requestMatchers("/images/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/**").hasAnyRole("USER", "ADMIN")
                 )
-                .formLogin(formLogin -> formLogin
-                        .loginPage("/auth/login")
-                        .loginProcessingUrl("/auth/login")
-                        .usernameParameter("username")
-                        .passwordParameter("password")
-                        .defaultSuccessUrl("/")
-                )
-                .rememberMe(rm -> rm.rememberMeParameter("remember")
-                        .alwaysRemember(false)
-                        .tokenValiditySeconds(2592000)
-                )
-                .userDetailsService(userDetailsService())
-                .csrf(AbstractHttpConfigurer::disable)
+                .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(customAuthenticationEntryPoint))
+                .with(authenticationManagerConfig, customizer -> {})
                 .build();
-    }
 
-    @Bean
-    public UserDetailsService userDetailsService() {
-        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-        UserDetails user = User.withUsername("hyein")
-                .password("1234")
-                .roles("ADMIN")
-                .build();
-        manager.createUser(user);
-        return manager;
     }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(httpRequest -> httpRequest
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers("/").permitAll()
-                        .requestMatchers("/members/signup", "/members/login", "/members/refreshToken").permitAll()
+                        .requestMatchers("/auth/signup", "/auth/login", "/auth/refreshToken").permitAll()
                         .requestMatchers(HttpMethod.GET, "/categories/**").permitAll()
                         .requestMatchers("/images/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("USER", "ADMIN")

--- a/src/main/java/com/generic/typed/config/WebConfig.java
+++ b/src/main/java/com/generic/typed/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.generic.typed.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:5173",
+                        frontendUrl
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/generic/typed/config/WebConfig.java
+++ b/src/main/java/com/generic/typed/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.generic.typed.config;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -8,17 +7,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Value("${frontend.url}")
-    private String frontendUrl;
-
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:5173",
-                        frontendUrl
-                )
+                .allowedOriginPatterns("*") // 모든 클라이언트 허용 접근
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
-                .allowCredentials(true);
+                .allowedHeaders("*") // 모든 header 허용
+                .exposedHeaders("Authorization", "RefreshToken")
+                .allowCredentials(true); // 모바일 앱 지원은 credentials 불필요
     }
 }

--- a/src/main/java/com/generic/typed/controller/AuthController.java
+++ b/src/main/java/com/generic/typed/controller/AuthController.java
@@ -1,0 +1,14 @@
+package com.generic.typed.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+@Slf4j
+@RestController
+public class AuthController {
+
+    @GetMapping("/auth/login")
+    public String login() {
+        return "로그인 스크린";
+    }
+}

--- a/src/main/java/com/generic/typed/controller/AuthController.java
+++ b/src/main/java/com/generic/typed/controller/AuthController.java
@@ -1,14 +1,118 @@
 package com.generic.typed.controller;
 
+import com.generic.typed.domain.Member;
+import com.generic.typed.domain.RefreshToken;
+import com.generic.typed.dto.request.MemberLoginRequest;
+import com.generic.typed.dto.request.MemberSignupRequest;
+import com.generic.typed.dto.request.RefreshTokenRequest;
+import com.generic.typed.dto.response.MemberLoginResponse;
+import com.generic.typed.dto.response.MemberSignupResponse;
+import com.generic.typed.security.jwt.util.JwtTokenizer;
+import com.generic.typed.service.MemberService;
+import com.generic.typed.service.RefreshTokenService;
+import com.generic.typed.domain.Role;
+
+import io.jsonwebtoken.Claims;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 @Slf4j
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
 public class AuthController {
+    private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenService refreshTokenService;
 
-    @GetMapping("/auth/login")
-    public String login() {
-        return "로그인 스크린";
+    @PostMapping("/signup")
+    public ResponseEntity signup(@RequestBody @Valid MemberSignupRequest request, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        Member member = new Member();
+        member.setNickname(request.getNickname());
+        member.setEmail(request.getEmail());
+        member.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        Member saveMember = memberService.addMember(member);
+
+        MemberSignupResponse response = new MemberSignupResponse();
+        response.setMemberId(saveMember.getId());
+        response.setNickname(saveMember.getNickname());
+        response.setCreatedAt(saveMember.getCreatedAt());
+        response.setEmail(saveMember.getEmail());
+
+        return new ResponseEntity(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody @Valid MemberLoginRequest login, BindingResult bindingResult) {
+
+        if(bindingResult.hasErrors()) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+
+        Member member = memberService.findByEmail(login.getEmail());
+        if(!passwordEncoder.matches(login.getPassword(), member.getPassword())) {
+            return new ResponseEntity(HttpStatus.UNAUTHORIZED);
+        }
+
+        List<String> roles = member.getRoles().stream().map(Role::getName).collect(Collectors.toList());
+
+        // JWT 토큰 생성
+        String accessToken = jwtTokenizer.createAccessToken(member.getId(),member.getEmail(),member.getNickname(), roles);
+        String refreshToken = jwtTokenizer.createRefreshToken(member.getId(),member.getEmail(),member.getNickname(), roles);
+
+        RefreshToken refreshTokenEntity = new RefreshToken();
+        refreshTokenEntity.setValue(refreshToken);
+        refreshTokenEntity.setMemberId(member.getId());
+        refreshTokenService.addRefreshToken(refreshTokenEntity);
+
+        MemberLoginResponse loginResponse = MemberLoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .build();
+        return new ResponseEntity(loginResponse, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity logout(@RequestBody RefreshTokenRequest refreshTokenRequest) {
+        refreshTokenService.deleteRefreshToken(refreshTokenRequest.getRefreshToken());
+        return new ResponseEntity(HttpStatus.OK);
+    }
+    @PostMapping("/refreshToken")
+    public ResponseEntity requestRefresh(@RequestBody RefreshTokenRequest refreshTokenRequest) {
+        RefreshToken refreshToken = refreshTokenService.findRefreshToken(refreshTokenRequest.getRefreshToken()).orElseThrow(() -> new IllegalArgumentException("Refresh token 값을 찾을 수 없습니다"));
+        Claims claims = jwtTokenizer.parseRefreshToken(refreshToken.getValue());
+
+        Long memberId = Long.valueOf((Integer)claims.get("memberId"));
+
+        Member member = memberService.getMember(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
+
+
+        List roles = (List) claims.get("roles");
+        String email = claims.getSubject();
+
+        String accessToken = jwtTokenizer.createAccessToken(memberId, email, member.getNickname(), roles);
+
+        MemberLoginResponse loginResponse = MemberLoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshTokenRequest.getRefreshToken())
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .build();
+        return new ResponseEntity(loginResponse, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/generic/typed/controller/MainController.java
+++ b/src/main/java/com/generic/typed/controller/MainController.java
@@ -1,0 +1,13 @@
+package com.generic.typed.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MainController {
+
+    @GetMapping("/")
+    public String main() {
+        return "메인 스크린";
+    }
+}

--- a/src/main/java/com/generic/typed/domain/Member.java
+++ b/src/main/java/com/generic/typed/domain/Member.java
@@ -1,0 +1,59 @@
+package com.generic.typed.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "member")
+@NoArgsConstructor
+@Data
+public class Member {
+
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 255, unique = true)
+    private String nickname;
+
+    @Column(length = 50)
+    private String email;
+
+    @JsonIgnore
+    @Column(length = 500)
+    private String password;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @ManyToMany
+    @JoinTable(name = "member_role",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "memberId=" + id +
+                ", nickname='" + nickname + '\'' +
+                ", email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                ", createdAt=" + createdAt +
+                ", roles=" + roles +
+                '}';
+    }
+
+    public void addRole(Role role) {
+        roles.add(role);
+    }
+}

--- a/src/main/java/com/generic/typed/domain/RefreshToken.java
+++ b/src/main/java/com/generic/typed/domain/RefreshToken.java
@@ -1,0 +1,19 @@
+package com.generic.typed.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor
+@Data
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private String value;
+}

--- a/src/main/java/com/generic/typed/domain/Role.java
+++ b/src/main/java/com/generic/typed/domain/Role.java
@@ -1,0 +1,31 @@
+package com.generic.typed.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="role")
+@NoArgsConstructor
+@Getter
+@Setter
+public class Role {
+    @Id
+    @Column(name = "role_id")
+    private Long roleId;
+
+    @Column(length = 20)
+    private String name;
+
+    @Override
+    public String toString() {
+        return "Role{" +
+                "roleId=" + roleId +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/generic/typed/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/generic/typed/dto/request/MemberLoginRequest.java
@@ -1,0 +1,23 @@
+package com.generic.typed.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLoginRequest {
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$")
+    private String email;
+
+    @NotEmpty
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$")
+    private String password;
+}

--- a/src/main/java/com/generic/typed/dto/request/MemberSignupRequest.java
+++ b/src/main/java/com/generic/typed/dto/request/MemberSignupRequest.java
@@ -24,7 +24,7 @@ public class MemberSignupRequest {
     private String password;
 
     @NotEmpty
-    @Pattern(regexp = "^[a-zA-Z가-힣\\\\s]{2,15}",
+    @Pattern(regexp = "^[a-zA-Z가-힣]{2,15}$",
             message = "이름은 2~15자 사이의 공백포함 영문자, 한글이어야 합니다")
     private String nickname;
 

--- a/src/main/java/com/generic/typed/dto/request/MemberSignupRequest.java
+++ b/src/main/java/com/generic/typed/dto/request/MemberSignupRequest.java
@@ -1,0 +1,31 @@
+package com.generic.typed.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "올바른 이메일 형식을 입력해주세요")
+    private String email;
+
+    @NotEmpty
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$",
+            message = "비밀번호는 영문+숫자+특수문자를 포함한 8~20자여야 합니다")
+    private String password;
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z가-힣\\\\s]{2,15}",
+            message = "이름은 2~15자 사이의 공백포함 영문자, 한글이어야 합니다")
+    private String nickname;
+
+}

--- a/src/main/java/com/generic/typed/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/generic/typed/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.generic.typed.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+
+    @NotEmpty
+    String refreshToken;
+}

--- a/src/main/java/com/generic/typed/dto/response/MemberLoginResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/MemberLoginResponse.java
@@ -1,0 +1,18 @@
+package com.generic.typed.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberLoginResponse {
+    private String accessToken;
+    private String refreshToken;
+
+    private Long memberId;
+    private String nickname;
+}

--- a/src/main/java/com/generic/typed/dto/response/MemberSignupResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/MemberSignupResponse.java
@@ -1,0 +1,15 @@
+package com.generic.typed.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class MemberSignupResponse {
+    private Long memberId;
+    private String nickname;
+    private String email;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/generic/typed/repository/MemberRepository.java
+++ b/src/main/java/com/generic/typed/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.generic.typed.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.generic.typed.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
+}

--- a/src/main/java/com/generic/typed/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/generic/typed/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.generic.typed.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.generic.typed.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByValue(String value);
+}

--- a/src/main/java/com/generic/typed/repository/RoleRepository.java
+++ b/src/main/java/com/generic/typed/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package com.generic.typed.repository;
+
+import com.generic.typed.domain.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}

--- a/src/main/java/com/generic/typed/security/jwt/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/generic/typed/security/jwt/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,61 @@
+package com.generic.typed.security.jwt.exception;
+
+import com.google.gson.Gson;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        String exception = (String) request.getAttribute("exception");
+        log.error("Commence Get Exception : {}", exception);
+
+        if(exception == null) {
+            log.error("entry point >> exception is null");
+            setResponse(response, JwtExceptionCode.NOT_FOUND_TOKEN);
+        }
+        else if(exception.equals(JwtExceptionCode.INVALID_TOKEN.getCode())) {
+            log.error("entry point >> invalid token");
+            setResponse(response, JwtExceptionCode.INVALID_TOKEN);
+        }
+        else if(exception.equals(JwtExceptionCode.EXPIRED_TOKEN.getCode())) {
+            log.error("entry point >> expired token");
+            setResponse(response, JwtExceptionCode.EXPIRED_TOKEN);
+        }
+        else if(exception.equals(JwtExceptionCode.UNSUPPORTED_TOKEN.getCode())) {
+            log.error("entry point >> unsupported token");
+            setResponse(response, JwtExceptionCode.UNSUPPORTED_TOKEN);
+        }
+        else if (exception.equals(JwtExceptionCode.NOT_FOUND_TOKEN.getCode())) {
+            log.error("entry point >> not found token");
+            setResponse(response, JwtExceptionCode.NOT_FOUND_TOKEN);
+        }
+        else {
+            setResponse(response, JwtExceptionCode.UNKNOWN_ERROR);
+        }
+
+    }
+
+    private void setResponse(HttpServletResponse response, JwtExceptionCode exceptionCode) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        HashMap<String, Object> errorInfo = new HashMap<>();
+        errorInfo.put("message", exceptionCode.getMessage());
+        errorInfo.put("code", exceptionCode.getCode());
+        Gson gson = new Gson();
+        String responseJson = gson.toJson(errorInfo);
+        response.getWriter().print(responseJson);
+    }
+}

--- a/src/main/java/com/generic/typed/security/jwt/exception/JwtExceptionCode.java
+++ b/src/main/java/com/generic/typed/security/jwt/exception/JwtExceptionCode.java
@@ -1,0 +1,23 @@
+package com.generic.typed.security.jwt.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtExceptionCode {
+
+    UNKNOWN_ERROR("UNKNOWN_ERROR", "UNKNOWN_ERROR"),
+    NOT_FOUND_TOKEN("NOT_FOUND_TOKEN", "Headers에 토큰 형식의 값 찾을 수 없음"),
+    INVALID_TOKEN("INVALID_TOKEN", "유효하지 않은 토큰"),
+    EXPIRED_TOKEN("EXPIRED_TOKEN", "기간이 만료된 토큰"),
+    UNSUPPORTED_TOKEN("UNSUPPORTED_TOKEN", "지원하지 않는 토큰");
+
+
+    private String code;
+
+    private String message;
+
+    JwtExceptionCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/generic/typed/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/generic/typed/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,120 @@
+package com.generic.typed.security.jwt.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.generic.typed.security.jwt.exception.JwtExceptionCode;
+import com.generic.typed.security.jwt.token.JwtAuthenticationToken;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        AntPathMatcher pathMatcher = new AntPathMatcher();
+
+        String[] categoryPatterns = {
+                "/categories",
+                "/categories/*/subcategories",
+                "/categories/*/subcategories/all",
+                "/categories/*/subcategories/*"
+        };
+
+        boolean shouldNotFilter = Arrays.stream(categoryPatterns)
+                .anyMatch(pattern -> {
+                    boolean matched = pathMatcher.match(pattern, path);
+                    return matched;
+                });
+
+        return shouldNotFilter || Arrays.asList("/", "/members/signup", "/members/login", "/members/refreshToken").contains(path);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = "";
+        try {
+            token = getToken(request);
+            log.info("추출된 토큰 값:[{}]", token);
+            log.info("Token length: {}", (token != null ? token.length() : "null"));
+            log.info("StringUtils.hasText result: {}", StringUtils.hasText(token));
+            if (StringUtils.hasText(token)) {
+                log.info("토큰 유효성 통과, 인증을 위한 과정 진행중");
+                getAuthentication(token);
+            } else {
+                log.info("토큰 유효성 실패");
+            }
+            filterChain.doFilter(request, response);
+        } catch (NullPointerException | IllegalStateException e) {
+            request.setAttribute("exception", JwtExceptionCode.NOT_FOUND_TOKEN.getCode());
+            log.error("Not found Token // token : {}", token);
+            log.error("Set Request Exception Code : {}", request.getAttribute("exception"));
+            throw new BadCredentialsException("throw new not found token exception");
+        } catch (SecurityException | MalformedJwtException e) {
+            request.setAttribute("exception", JwtExceptionCode.INVALID_TOKEN.getCode());
+            log.error("Invalid Token // token : {}", token);
+            log.error("Set Request Exception Code : {}", request.getAttribute("exception"));
+            throw new BadCredentialsException("throw new invalid token exception");
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("exception", JwtExceptionCode.EXPIRED_TOKEN.getCode());
+            log.error("EXPIRED Token // token : {}", token);
+            log.error("Set Request Exception Code : {}", request.getAttribute("exception"));
+            throw new BadCredentialsException("throw new expired token exception");
+        } catch (UnsupportedJwtException e) {
+            request.setAttribute("exception", JwtExceptionCode.UNSUPPORTED_TOKEN.getCode());
+            log.error("Unsupported Token // token : {}", token);
+            log.error("Set Request Exception Code : {}", request.getAttribute("exception"));
+            throw new BadCredentialsException("throw new unsupported token exception");
+        } catch (Exception e) {
+            log.error("====================================================");
+            log.error("JwtFilter - doFilterInternal() 오류 발생");
+            log.error("token : {}", token);
+            log.error("Exception Message : {}", e.getMessage());
+            log.error("Exception StackTrace : {");
+            e.printStackTrace();
+            log.error("}");
+            log.error("====================================================");
+            throw new BadCredentialsException("throw new exception");
+        }
+    }
+
+    private String getToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (StringUtils.hasText(authorization) && authorization.startsWith("Bearer")) {
+            String[] arr = authorization.split(" ");
+            return arr[1];
+        }
+        return null;
+    }
+
+    private void getAuthentication(String token) {
+        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(token);
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(authentication);
+    }
+
+
+}

--- a/src/main/java/com/generic/typed/security/jwt/provider/JwtAuthenticationProvider.java
+++ b/src/main/java/com/generic/typed/security/jwt/provider/JwtAuthenticationProvider.java
@@ -1,0 +1,45 @@
+package com.generic.typed.security.jwt.provider;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+import com.generic.typed.security.jwt.token.JwtAuthenticationToken;
+import com.generic.typed.security.jwt.util.JwtTokenizer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final JwtTokenizer jwtTokenizer;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken authenticationToken = (JwtAuthenticationToken) authentication;
+        Claims claims = jwtTokenizer.parseAccessToken(authenticationToken.getToken());
+        String email = claims.getSubject();
+        List<GrantedAuthority> authorities = getGrantedAuthorities(claims);
+
+        return new JwtAuthenticationToken(authorities, email, null);
+    }
+
+    private List<GrantedAuthority> getGrantedAuthorities(Claims claims) {
+        List<String> roles = (List<String>) claims.get("roles");
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (String role : roles) {
+            authorities.add(()-> role);
+        }
+        return authorities;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/generic/typed/security/jwt/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/generic/typed/security/jwt/token/JwtAuthenticationToken.java
@@ -1,0 +1,34 @@
+package com.generic.typed.security.jwt.token;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+@Getter
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private String token;
+    private Object principal;
+    private Object credentials;
+
+    public JwtAuthenticationToken(Collection<? extends GrantedAuthority> authorities, Object principal, Object credentials) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        this.setAuthenticated(true);
+    }
+
+    public JwtAuthenticationToken(String token) {
+        super(null);
+        this.token = token;
+        this.setAuthenticated(false);
+    }
+
+    @Override
+    public Object getPrincipal() { return this.principal;}
+
+    @Override
+    public Object getCredentials() { return this.credentials;}
+
+}

--- a/src/main/java/com/generic/typed/security/jwt/util/IfLogin.java
+++ b/src/main/java/com/generic/typed/security/jwt/util/IfLogin.java
@@ -1,0 +1,12 @@
+package com.generic.typed.security.jwt.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IfLogin {
+}
+

--- a/src/main/java/com/generic/typed/security/jwt/util/IfLoginArgumentResolver.java
+++ b/src/main/java/com/generic/typed/security/jwt/util/IfLoginArgumentResolver.java
@@ -1,0 +1,59 @@
+package com.generic.typed.security.jwt.util;
+
+import com.generic.typed.security.jwt.token.JwtAuthenticationToken;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class IfLoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(IfLogin.class) != null
+                && parameter.getParameterType() == LoginMemberDto.class;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = null;
+        try {
+            authentication = SecurityContextHolder.getContext().getAuthentication();
+        } catch (Exception ex) {
+            return null;
+        }
+        if (authentication == null) {
+            return null;
+        }
+
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken)authentication;
+        LoginMemberDto loginMemberDto = new LoginMemberDto();
+
+        Object principal = jwtAuthenticationToken.getPrincipal(); // LoginInfoDto
+        if (principal == null)
+            return null;
+
+        LoginInfoDto loginInfoDto = (LoginInfoDto)principal;
+        loginMemberDto.setEmail(loginInfoDto.getEmail());
+        loginMemberDto.setMemberId(loginInfoDto.getMemberId());
+        loginMemberDto.setNickname(loginInfoDto.getNickname());
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        while (iterator.hasNext()) {
+            GrantedAuthority grantedAuthority = iterator.next();
+            String role = grantedAuthority.getAuthority();
+            loginMemberDto.addRole(role);
+        }
+
+        return loginMemberDto;
+    }
+}

--- a/src/main/java/com/generic/typed/security/jwt/util/JwtTokenizer.java
+++ b/src/main/java/com/generic/typed/security/jwt/util/JwtTokenizer.java
@@ -1,0 +1,91 @@
+package com.generic.typed.security.jwt.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtTokenizer {
+
+    private final byte[] accessSecret;
+
+    private final byte[] refreshSecret;
+
+    public final static Long ACCESS_TOKEN_EXPIRE_COUNT = 30 * 60 * 1000L;
+    public final static Long REFRESH_TOKEN_EXPIRE_COUNT = 7 * 24 * 60 * 60 * 1000L;
+
+    /// TODO : 운영 환경에서 환경 변수 설정
+    public JwtTokenizer(@Value("${jwt.secretKey}") String accessSecret, @Value("${jwt.refreshKey}") String refreshSecret) {
+        this.accessSecret = accessSecret.getBytes(StandardCharsets.UTF_8);
+        this.refreshSecret = refreshSecret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * AccessToken 생성
+     */
+    public String createAccessToken(Long id, String email, String name, List<String> roles) {
+        return createToken(id, email, name, roles, ACCESS_TOKEN_EXPIRE_COUNT, accessSecret);
+    }
+
+    /**
+     * RefreshToken 생성
+     */
+    public String createRefreshToken(Long id, String email, String name, List<String> roles) {
+        return createToken(id, email, name, roles, REFRESH_TOKEN_EXPIRE_COUNT, refreshSecret);
+    }
+
+    private String createToken(Long id, String email, String name, List<String> roles, Long expire, byte[] secretKey) {
+
+        Claims claims = Jwts.claims()
+                .subject(email)
+                .add("roles", roles)
+                .add("memberId", id)
+                .add("memberName", name)
+                .build();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(new Date().getTime() + expire))
+                .signWith(getSigningKey(secretKey))
+                .compact();
+    }
+
+    /**
+     * 토큰에서 사용자 아이디 얻기
+     */
+    public Long getMemberIdFromToken(String token) {
+        String[] tokenArr = token.split(" ");
+        token = tokenArr[1];
+        Claims claims = parseToken(token, accessSecret);
+        return Long.valueOf((Integer) claims.get("memberId"));
+    }
+
+    public Claims parseAccessToken(String accessToken) {
+        return parseToken(accessToken, accessSecret);
+    }
+
+    public Claims parseRefreshToken(String refreshToken) {
+        return parseToken(refreshToken, refreshSecret);
+    }
+
+    public Claims parseToken(String token, byte[] secretKey) {
+        return Jwts.parser()
+                .setSigningKey(getSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+
+    public static Key getSigningKey(byte[] secretKey) {
+        return Keys.hmacShaKeyFor(secretKey);
+    }
+}

--- a/src/main/java/com/generic/typed/security/jwt/util/LoginInfoDto.java
+++ b/src/main/java/com/generic/typed/security/jwt/util/LoginInfoDto.java
@@ -1,0 +1,11 @@
+package com.generic.typed.security.jwt.util;
+
+import lombok.Data;
+
+@Data
+public class LoginInfoDto {
+
+    private Long memberId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/generic/typed/security/jwt/util/LoginMemberDto.java
+++ b/src/main/java/com/generic/typed/security/jwt/util/LoginMemberDto.java
@@ -1,0 +1,20 @@
+package com.generic.typed.security.jwt.util;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class LoginMemberDto {
+
+    private String email;
+    private String nickname;
+    private Long memberId;
+    private List<String> roles = new ArrayList<>();
+
+    public void addRole(String role){
+        roles.add(role);
+    }
+
+}

--- a/src/main/java/com/generic/typed/service/MemberService.java
+++ b/src/main/java/com/generic/typed/service/MemberService.java
@@ -1,0 +1,51 @@
+package com.generic.typed.service;
+
+import com.generic.typed.domain.Member;
+import com.generic.typed.domain.Role;
+import com.generic.typed.repository.MemberRepository;
+import com.generic.typed.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+
+    @Transactional(readOnly = true)
+    public Member findByEmail(String email){
+        return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다."));
+    }
+
+    @Transactional
+    public Member addMember(Member member) {
+
+        if (memberRepository.findByEmail(member.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        if (memberRepository.findByNickname(member.getNickname()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용중인 사용자 이름입니다.");
+        }
+        Optional<Role> userRole = roleRepository.findByName("ROLE_USER");
+        member.addRole(userRole.get());
+        Member saveMember = memberRepository.save(member);
+        return saveMember;
+    }
+
+
+    @Transactional(readOnly = true)
+    public Optional<Member> getMember(Long memberId){
+        return memberRepository.findById(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> getMember(String email){
+        return memberRepository.findByEmail(email);
+    }
+}

--- a/src/main/java/com/generic/typed/service/RefreshTokenService.java
+++ b/src/main/java/com/generic/typed/service/RefreshTokenService.java
@@ -1,0 +1,31 @@
+package com.generic.typed.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.generic.typed.domain.RefreshToken;
+import com.generic.typed.repository.RefreshTokenRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public RefreshToken addRefreshToken(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRepository.findByValue(refreshToken).ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByValue(refreshToken);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
## Request

```json
{
	"nickname" : "2~15자, 영문/숫자/한글",
	"email" : "이메일",
	"password" : "8자이상, 대소문자/특수문자 섞은 암호"
}
```

```json
{
	"Id" : 1
	"nickname" : "이름",
	"email" : "이메일", 
	"createdAt": "2025-01-30 12:08:21"
}
```

## Response

1. Post Body로 넘어오는 데이터를 검증
2. Member 엔티티 생성 ( 암호는 암호화해서 설정 )
3. Member 저장 (id 자동 생성됨)
4. memberId , memberName , email 반환
----
## Request

```json
{
	"email" : "이메일",
	"password" : "비밀번호"
}
```

## Response

```json
{
    "accessToken": "JWT토큰",
    "refreshToken": "JWT토큰",
    "Id":  1
    "nickname": "닉네임"
    "email": "user@example.com"
}
```

1. email 해당하는 사용자가 있는지 검사
2. PasswordEncoder의 matchers를 이용해 암호 검사
3. JWT Access Token, Refresh Token 생성
4. 응답에 JWT토큰, memberId, name을 출력
