### PR TITLE
Feat/review : 서평 관련 API에서 비로그인 사용자 지원 코드 제거

### DIFF
--- a/src/main/java/com/generic/typed/config/RestTemplateConfig.java
+++ b/src/main/java/com/generic/typed/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package com.generic.typed.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/generic/typed/config/SecurityConfig.java
+++ b/src/main/java/com/generic/typed/config/SecurityConfig.java
@@ -36,15 +36,10 @@ public class SecurityConfig {
                         .requestMatchers("/").permitAll()
                         .requestMatchers("/auth/signup", "/auth/login", "/auth/refreshToken").permitAll()
                         .requestMatchers(HttpMethod.GET, "/books/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/reveiws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/sentences").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/sentences/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/sentences/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/reviews/**").permitAll()
-                        .requestMatchers(HttpMethod.PUT, "/sentences/**").permitAll()
-                        .requestMatchers(HttpMethod.PUT, "/reviews/**").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/sentences/**").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/reviews/**").permitAll()
+                        // 문장 관련 API는 인증 필요
+                        .requestMatchers(HttpMethod.GET, "/sentences").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/sentences").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/sentences/**").authenticated()
                         .requestMatchers("/images/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("USER", "ADMIN")
                         .requestMatchers(HttpMethod.POST, "/**").hasAnyRole("USER", "ADMIN")
@@ -52,7 +47,6 @@ public class SecurityConfig {
                 .exceptionHandling(httpSecurityExceptionHandlingConfigurer -> httpSecurityExceptionHandlingConfigurer.authenticationEntryPoint(customAuthenticationEntryPoint))
                 .with(authenticationManagerConfig, customizer -> {})
                 .build();
-
     }
 
     @Bean

--- a/src/main/java/com/generic/typed/controller/ReviewController.java
+++ b/src/main/java/com/generic/typed/controller/ReviewController.java
@@ -1,0 +1,68 @@
+package com.generic.typed.controller;
+
+import com.generic.typed.dto.request.ReviewCreateRequest;
+import com.generic.typed.dto.response.MyReviewListResponse;
+import com.generic.typed.dto.response.MyReviewResponse;
+import com.generic.typed.dto.response.ReviewCreateResponse;
+import com.generic.typed.security.jwt.util.IfLogin;
+import com.generic.typed.security.jwt.util.LoginMemberDto;
+import com.generic.typed.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    /**
+     * 서평 등록 - 로그인 필요
+     */
+    @PostMapping
+    public ResponseEntity<ReviewCreateResponse> createReview(
+            @IfLogin LoginMemberDto loginMemberDto,
+            @RequestBody ReviewCreateRequest request) {
+
+        ReviewCreateResponse response = reviewService.createReview(loginMemberDto.getEmail(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 내 서평 목록 조회 - 로그인 필요
+     */
+    @GetMapping("/my")
+    public ResponseEntity<MyReviewListResponse> getMyReviews(
+            @IfLogin LoginMemberDto loginMemberDto) {
+
+        MyReviewListResponse response = reviewService.getMyReviews(loginMemberDto.getEmail());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 서평 수정 - 로그인 필요
+     */
+    @PutMapping("/{reviewId}")
+    public ResponseEntity<MyReviewResponse> updateReview(
+            @IfLogin LoginMemberDto loginMemberDto,
+            @PathVariable("reviewId") Long reviewId,
+            @RequestBody ReviewCreateRequest request) {
+
+        MyReviewResponse response = reviewService.updateReview(loginMemberDto.getEmail(), reviewId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 서평 삭제 - 로그인 필요
+     */
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> deleteReview(
+            @IfLogin LoginMemberDto loginMemberDto,
+            @PathVariable("reviewId") Long reviewId) {
+
+        reviewService.deleteReview(loginMemberDto.getEmail(), reviewId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/generic/typed/domain/Review.java
+++ b/src/main/java/com/generic/typed/domain/Review.java
@@ -1,0 +1,69 @@
+package com.generic.typed.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false, length = 10000)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isPublic;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    @Column(length = 100)
+    private String deviceId;
+
+    // 책 관련 정보
+    @Column(length = 200)
+    private String bookTitle;
+
+    @Column(length = 100)
+    private String bookAuthor;
+
+    @Column(length = 500)
+    private String bookThumbnail;
+
+    @Column(length = 20)
+    private String isbn;
+
+    public Review(String content, boolean isPublic, LocalDateTime createdAt, Member member, String deviceId,
+                  String bookTitle, String bookAuthor, String bookThumbnail, String isbn) {
+        this.content = content;
+        this.isPublic = isPublic;
+        this.createdAt = createdAt;
+        this.member = member;
+        this.deviceId = deviceId;
+        this.bookTitle = bookTitle;
+        this.bookAuthor = bookAuthor;
+        this.bookThumbnail = bookThumbnail;
+        this.isbn = isbn;
+    }
+
+    public void update(String content, boolean isPublic) {
+        this.content = content;
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/com/generic/typed/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/generic/typed/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,42 @@
+package com.generic.typed.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Setter
+@Getter
+@ToString
+@NoArgsConstructor
+public class ReviewCreateRequest {
+    @NotBlank(message = "내용을 입력해주세요")
+    private String content;
+    @JsonProperty("isPublic")
+    private boolean isPublic;
+
+    private String bookIsbn;
+
+    private String bookTitle;
+
+    private String thumbnail;
+
+    @Builder
+    public ReviewCreateRequest(String content, boolean isPublic, String bookIsbn,
+                               String bookTitle, String thumbnail) {
+        this.content = content;
+        this.isPublic = isPublic;
+        this.bookIsbn = bookIsbn;
+        this.bookTitle = bookTitle;
+        this.thumbnail = thumbnail;
+    }
+
+    public void validate() {
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("서평 내용을 입력해주세요");
+        }
+
+        if (bookTitle == null || bookTitle.trim().isEmpty()) {
+            throw new IllegalArgumentException("책 제목을 입력해주세요");
+        }
+    }
+}

--- a/src/main/java/com/generic/typed/dto/response/BookSearchResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/BookSearchResponse.java
@@ -1,0 +1,43 @@
+package com.generic.typed.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BookSearchResponse {
+    private List<BookDocument> documents;
+    private BookMeta meta;
+
+    @Data
+    public static class BookDocument {
+        private List<String> authors;
+        private String contents = "";
+        private String datetime = "";
+        private String isbn = "";
+        private int price;
+        private String publisher;
+
+        @JsonProperty("sale_price")
+        private int salePrice;
+
+        private String status;
+        private String thumbnail;
+        private String title;
+        private List<String> translators;
+        private String url;
+    }
+
+    @Data
+    public static class BookMeta {
+        @JsonProperty("is_end")
+        private boolean isEnd;
+
+        @JsonProperty("pageable_count")
+        private int pageableCount;
+
+        @JsonProperty("total_count")
+        private int totalCount;
+    }
+}

--- a/src/main/java/com/generic/typed/dto/response/MyReviewListResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/MyReviewListResponse.java
@@ -1,0 +1,34 @@
+package com.generic.typed.dto.response;
+
+import com.generic.typed.domain.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class MyReviewListResponse {
+    private final List<MyReviewResponse> reviews;
+
+    @Builder
+    public MyReviewListResponse(List<MyReviewResponse> reviews) {
+        // reviews가 null인 경우 빈 리스트로 초기화
+        this.reviews = reviews != null ? reviews : Collections.emptyList();
+    }
+
+    public static MyReviewListResponse from(List<Review> reviews) {
+        if (reviews == null) {
+            return new MyReviewListResponse(Collections.emptyList());
+        }
+
+        List<MyReviewResponse> reviewResponses = reviews.stream()
+                .map(MyReviewResponse::from)
+                .collect(Collectors.toList());
+
+        return MyReviewListResponse.builder()
+                .reviews(reviewResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/generic/typed/dto/response/MyReviewResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/MyReviewResponse.java
@@ -1,0 +1,49 @@
+package com.generic.typed.dto.response;
+
+import com.generic.typed.domain.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MyReviewResponse {
+    private final Long id;
+    private final String content;
+    private final boolean isPublic;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final String bookTitle;
+    private final String bookAuthor;
+    private final String bookThumbnail;
+    private final String authorNickname;
+
+    @Builder
+    public MyReviewResponse(Long id, String content, boolean isPublic, LocalDateTime createdAt,
+                          LocalDateTime updatedAt, String bookTitle, String bookAuthor,
+                          String bookThumbnail, String authorNickname) {
+        this.id = id;
+        this.content = content;
+        this.isPublic = isPublic;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.bookTitle = bookTitle;
+        this.bookAuthor = bookAuthor;
+        this.bookThumbnail = bookThumbnail;
+        this.authorNickname = authorNickname;
+    }
+
+    public static MyReviewResponse from(Review review) {
+        return MyReviewResponse.builder()
+                .id(review.getId())
+                .content(review.getContent())
+                .isPublic(review.isPublic())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .bookTitle(review.getBookTitle())
+                .bookAuthor(review.getBookAuthor())
+                .bookThumbnail(review.getBookThumbnail())
+                .authorNickname(review.getMember() != null ? review.getMember().getNickname() : "익명")
+                .build();
+    }
+}

--- a/src/main/java/com/generic/typed/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/generic/typed/dto/response/ReviewCreateResponse.java
@@ -1,0 +1,31 @@
+package com.generic.typed.dto.response;
+
+import com.generic.typed.domain.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewCreateResponse {
+    private final Long id;
+    private final String content;
+    private final boolean isPublic;
+    private final LocalDateTime createdAt;
+    private final String bookTitle;
+    private final String bookIsbn;
+    private final String thumbnail;
+
+    public static ReviewCreateResponse from(Review review) {
+        return ReviewCreateResponse.builder()
+                .id(review.getId())
+                .content(review.getContent())
+                .isPublic(review.isPublic())
+                .createdAt(review.getCreatedAt())
+                .bookTitle(review.getBookTitle())
+                .bookIsbn(review.getIsbn())
+                .thumbnail(review.getBookThumbnail())
+                .build();
+    }
+}

--- a/src/main/java/com/generic/typed/kakaoApi/BookController.java
+++ b/src/main/java/com/generic/typed/kakaoApi/BookController.java
@@ -1,0 +1,43 @@
+package com.generic.typed.kakaoApi;
+
+
+import com.generic.typed.dto.response.BookSearchResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/books")
+public class BookController {
+    private final KakaoBookApi bookApi;
+
+    /**
+     * 책 검색 API
+     * 클라이언트에서는 먼저 이 API를 호출하여 책을 검색하고,
+     * 선택한 책의 ISBN으로 서평을 작성합니다.
+     */
+    @GetMapping("/search")
+    public ResponseEntity<BookSearchResponse> searchBooks(@RequestParam(name = "query") String query) {
+
+        log.info("Search Query: {}", query);
+
+        BookSearchResponse result = bookApi.searchBooks(query);
+
+        log.info("Search Result: {}", result);
+        log.info("Documents Count: {}",
+                result.getDocuments() != null ? result.getDocuments().size() : "null");
+
+        if (result.getDocuments() == null || result.getDocuments().isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/src/main/java/com/generic/typed/kakaoApi/KakaoBookApi.java
+++ b/src/main/java/com/generic/typed/kakaoApi/KakaoBookApi.java
@@ -1,0 +1,75 @@
+package com.generic.typed.kakaoApi;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.generic.typed.dto.response.BookSearchResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@Slf4j
+public class KakaoBookApi {
+
+    private final RestTemplate restTemplate;
+    private final String kakaoApiKey;
+    private static final String KAKAO_BOOK_API_URL = "https://dapi.kakao.com/v3/search/book";
+
+    public KakaoBookApi(@Value("${kakao.api.key}") String kakaoApiKey) {
+        this.restTemplate = new RestTemplate();
+        this.kakaoApiKey = kakaoApiKey;
+    }
+
+    public BookSearchResponse searchBooks(String query) {
+        try {
+            String encodedQuery = URLEncoder.encode(query, StandardCharsets.UTF_8.toString());
+            URL url = new URL(KAKAO_BOOK_API_URL + "?query=" + encodedQuery + "&size=10");
+
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "KakaoAK " + kakaoApiKey);
+            conn.setRequestProperty("Content-Type", "application/json");
+
+            int responseCode = conn.getResponseCode();
+            log.info("Response Code: {}", responseCode);
+
+            BufferedReader in;
+            if (responseCode >= 200 && responseCode <= 300) {
+                in = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
+            } else {
+                in = new BufferedReader(new InputStreamReader(conn.getErrorStream(), StandardCharsets.UTF_8));
+            }
+
+            String inputLine;
+            StringBuilder response = new StringBuilder();
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+            log.info("Full Response: {}", response.toString());
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readValue(response.toString(), BookSearchResponse.class);
+
+        } catch (Exception e) {
+            log.error("책 검색 API 호출 중 오류", e);
+            return new BookSearchResponse();
+        }
+    }
+
+    public BookSearchResponse.BookDocument getBookByIsbn(String isbn) {
+        BookSearchResponse result = searchBooks("isbn:" + isbn);
+        if (result.getDocuments() != null && !result.getDocuments().isEmpty()) {
+            return result.getDocuments().get(0);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/generic/typed/repository/BookSearchRepository.java
+++ b/src/main/java/com/generic/typed/repository/BookSearchRepository.java
@@ -1,0 +1,10 @@
+package com.generic.typed.repository;
+
+import com.generic.typed.dto.response.BookSearchResponse;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BookSearchRepository {
+    BookSearchResponse searchBooks(String query);
+    BookSearchResponse searchBooksByIsbn(String isbn);
+}

--- a/src/main/java/com/generic/typed/repository/ReviewRepository.java
+++ b/src/main/java/com/generic/typed/repository/ReviewRepository.java
@@ -1,0 +1,12 @@
+package com.generic.typed.repository;
+
+import com.generic.typed.domain.Member;
+import com.generic.typed.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByMember(Member member);
+    List<Review> findByIsPublicTrue();
+}

--- a/src/main/java/com/generic/typed/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/generic/typed/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.generic.typed.security.jwt.filter;
 
+import com.generic.typed.security.jwt.exception.JwtExceptionCode;
+import com.generic.typed.security.jwt.token.JwtAuthenticationToken;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -16,11 +18,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import com.generic.typed.security.jwt.exception.JwtExceptionCode;
-import com.generic.typed.security.jwt.token.JwtAuthenticationToken;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -31,24 +30,38 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
+        String method = request.getMethod();
         AntPathMatcher pathMatcher = new AntPathMatcher();
 
-        String[] categoryPatterns = {
-                "/categories",
-                "/categories/*/subcategories",
-                "/categories/*/subcategories/all",
-                "/categories/*/subcategories/*",
-                "/sentences",
-                "/sentences/*",
+        log.debug("URI: {}, Method: {}", path, method);
+
+
+        // 2. 인증이 필요 없는 공개 API 경로만 정의
+        String[] publicPatterns = {
+                "/",                     // 메인 페이지
+                "/auth/signup",          // 회원가입
+                "/auth/login",           // 로그인
+                "/auth/refreshToken",    // 토큰 갱신
+                "/books/search",         // 책 검색 API
+                "/error"                 // 에러 페이지
+                // 기타 필요한 공개 API 추가
         };
 
-        boolean shouldNotFilter = Arrays.stream(categoryPatterns)
-                .anyMatch(pattern -> {
-                    boolean matched = pathMatcher.match(pattern, path);
-                    return matched;
-                });
+        // 3. OPTIONS 요청(CORS preflight)은 항상 허용
+        if (request.getMethod().equals("OPTIONS")) {
+            return true;
+        }
 
-        return shouldNotFilter || Arrays.asList("/", "/members/signup", "/members/login", "/members/refreshToken").contains(path);
+        // 4. 공개 API 패턴과 일치하는지 확인
+        for (String pattern : publicPatterns) {
+            if (pathMatcher.match(pattern, path)) {
+                log.debug("공개 API 경로 일치: {}", pattern);
+                return true;
+            }
+        }
+
+        // 5. 그 외 모든 API는 JWT 인증 필요
+        return false;
     }
 
     @Override

--- a/src/main/java/com/generic/typed/service/BookSearchService.java
+++ b/src/main/java/com/generic/typed/service/BookSearchService.java
@@ -1,0 +1,20 @@
+package com.generic.typed.service;
+
+import com.generic.typed.kakaoApi.KakaoBookApi;
+import com.generic.typed.dto.response.BookSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookSearchService {
+    private final KakaoBookApi kakaoBookApi;
+
+    public BookSearchResponse searchBooks(String query) {
+        return kakaoBookApi.searchBooks(query);
+    }
+
+    public BookSearchResponse searchBooksByIsbn(String isbn) {
+        return kakaoBookApi.searchBooks("isbn:" + isbn);
+    }
+}

--- a/src/main/java/com/generic/typed/service/ReviewService.java
+++ b/src/main/java/com/generic/typed/service/ReviewService.java
@@ -1,0 +1,126 @@
+package com.generic.typed.service;
+
+import com.generic.typed.domain.Member;
+import com.generic.typed.domain.Review;
+import com.generic.typed.dto.request.ReviewCreateRequest;
+import com.generic.typed.dto.response.BookSearchResponse;
+import com.generic.typed.dto.response.MyReviewListResponse;
+import com.generic.typed.dto.response.MyReviewResponse;
+import com.generic.typed.dto.response.ReviewCreateResponse;
+import com.generic.typed.kakaoApi.KakaoBookApi;
+import com.generic.typed.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final MemberService memberService;
+    private final KakaoBookApi bookApi;
+
+    @Transactional
+    public ReviewCreateResponse createReview(String email, ReviewCreateRequest request) {
+        // 요청 검증
+        request.validate();
+
+        // 사용자 정보 조회 (로그인 필수)
+        Member member = memberService.findByEmail(email);
+
+        // 책 정보 조회
+        String bookTitle = "";
+        String bookAuthor = "";
+        String bookThumbnail = "";
+        String isbn = request.getBookIsbn();
+
+        String bookQuery = request.getBookTitle();
+        if (bookQuery != null && !bookQuery.isEmpty()) {
+            BookSearchResponse searchResponse = bookApi.searchBooks(bookQuery);
+            if (searchResponse != null && searchResponse.getDocuments() != null && !searchResponse.getDocuments().isEmpty()) {
+                // 첫 번째 검색 결과 사용 (또는 사용자가 선택한 결과 사용)
+                BookSearchResponse.BookDocument book = searchResponse.getDocuments().get(0);
+                bookTitle = book.getTitle();
+                bookAuthor = String.join(", ", book.getAuthors());
+                bookThumbnail = book.getThumbnail();
+                isbn = book.getIsbn();
+            }
+        }
+
+        // 새 서평 엔티티 생성 (deviceId 없음)
+        Review review = new Review(
+                request.getContent(),
+                request.isPublic(),
+                LocalDateTime.now(),
+                member,
+                null, // deviceId 제거 (null로 전달)
+                bookTitle,
+                bookAuthor,
+                bookThumbnail,
+                isbn
+        );
+
+        // 저장
+        Review savedReview = reviewRepository.save(review);
+
+        // 응답 생성
+        return ReviewCreateResponse.from(savedReview);
+    }
+
+    @Transactional(readOnly = true)
+    public MyReviewListResponse getPublicReviews() {
+        List<Review> reviews = reviewRepository.findByIsPublicTrue();
+        return MyReviewListResponse.from(reviews);
+    }
+
+    @Transactional(readOnly = true)
+    public MyReviewListResponse getMyReviews(String email) {
+        // 로그인한 사용자의 리뷰만 조회
+        Member member = memberService.findByEmail(email);
+        List<Review> reviews = reviewRepository.findByMember(member);
+        return MyReviewListResponse.from(reviews);
+    }
+
+    @Transactional
+    public MyReviewResponse updateReview(String email, Long reviewId, ReviewCreateRequest request) {
+        // 요청 검증
+        request.validate();
+
+        // 로그인 사용자 확인
+        Member member = memberService.findByEmail(email);
+
+        // 리뷰 조회 및 권한 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서평입니다."));
+
+        if (!review.getMember().equals(member)) {
+            throw new IllegalArgumentException("해당 서평을 수정할 권한이 없습니다.");
+        }
+
+        // 서평 업데이트
+        review.update(request.getContent(), request.isPublic());
+
+        return MyReviewResponse.from(review);
+    }
+
+    @Transactional
+    public void deleteReview(String email, Long reviewId) {
+        // 로그인 사용자 확인
+        Member member = memberService.findByEmail(email);
+
+        // 리뷰 조회 및 권한 확인
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 서평입니다."));
+
+        if (!review.getMember().equals(member)) {
+            throw new IllegalArgumentException("해당 서평을 삭제할 권한이 없습니다.");
+        }
+
+        // 서평 삭제
+        reviewRepository.delete(review);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
: 비로그인 사용자 지원을 제거하고 로그인 사용자만 지원하도록 변경
: UUID 기반 디바이스 식별과 로그인 사용자 구분 로직 제거

- 컨트롤러에서 X-Device-Id 헤더 처리 제거
- 서비스 로직에서 디바이스 ID 관련 코드 제거
- 엔티티에서 deviceId 필드 관련 코드 수정
