### PR TITLE
refactor : 기존의 비로그인 사용자를 위한 문장 수집 API 코드 삭제

### DIFF
--- a/src/main/java/com/generic/typed/controller/SentenceController.java
+++ b/src/main/java/com/generic/typed/controller/SentenceController.java
@@ -1,10 +1,8 @@
 package com.generic.typed.controller;
 
 import com.generic.typed.dto.request.SentenceCreateRequest;
-import com.generic.typed.dto.request.SentenceUpdateRequest;
 import com.generic.typed.dto.response.MySentenceListResponse;
 import com.generic.typed.dto.response.SentenceCreateResponse;
-import com.generic.typed.dto.response.SentenceUpdateResponse;
 import com.generic.typed.security.jwt.util.IfLogin;
 import com.generic.typed.security.jwt.util.LoginMemberDto;
 import com.generic.typed.service.SentenceService;
@@ -13,96 +11,36 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/sentences")
 public class SentenceController {
     private final SentenceService sentenceService;
 
-    /**
-     * 문장 등록 - 로그인 불필요
-     * 로그인하지 않은 사용자는 deviceId로 구분
-     */
+
     @PostMapping
     public ResponseEntity<SentenceCreateResponse> createSentence(
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
-            @IfLogin(required = false) LoginMemberDto loginMemberDto,
+            @IfLogin LoginMemberDto loginMemberDto,  // required=true가 기본값
             @RequestBody SentenceCreateRequest request) {
 
-        System.out.println("Controller - X-Device-Id Header: " + deviceId);
-        System.out.println("Controller - LoginMemberDto: " + loginMemberDto);
-
-        // 로그인한 경우 email 사용, 비로그인 시 deviceId 사용
-        // 수정된 조건문
-        String userIdentifier = (loginMemberDto != null && loginMemberDto.getEmail() != null)
-                ? loginMemberDto.getEmail()
-                : (deviceId != null ? deviceId : UUID.randomUUID().toString());
-
-        System.out.println("Controller - UserIdentifier before service call: " + userIdentifier);
-
-        SentenceCreateResponse response = sentenceService.createSentence(userIdentifier, request);
-
+        SentenceCreateResponse response = sentenceService.createSentence(loginMemberDto.getEmail(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    /**
-     * 내 문장 목록 조회 - 로그인 불필요
-     * deviceId로 문장 소유자 구분
-     */
     @GetMapping("")
     public ResponseEntity<MySentenceListResponse> getMySentences(
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
-            @IfLogin(required = false) LoginMemberDto loginMemberDto) {
+            @IfLogin LoginMemberDto loginMemberDto) {
 
-        String userIdentifier = loginMemberDto != null && loginMemberDto.getEmail() != null
-                ? loginMemberDto.getEmail()
-                : (deviceId != null ? deviceId : "anonymous");
-
-        MySentenceListResponse response = sentenceService.getMySentences(userIdentifier);
+        MySentenceListResponse response = sentenceService.getMySentences(loginMemberDto.getEmail());
         return ResponseEntity.ok(response);
     }
 
-
-    /**
-     * 문장 수정 - 로그인 불필요, deviceId로 소유자 확인
-     */
-    @PutMapping("/{sentenceId}")
-    public ResponseEntity<SentenceUpdateResponse> updateSentence(
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
-            @IfLogin(required = false) LoginMemberDto loginMemberDto,
-            @PathVariable("sentenceId") Long sentenceId,
-            @RequestBody SentenceUpdateRequest request) {
-
-        String userIdentifier = loginMemberDto != null && loginMemberDto.getEmail() != null
-                ? loginMemberDto.getEmail()
-                : (deviceId != null
-                ? deviceId
-                : "anonymous");
-
-        SentenceUpdateResponse response = sentenceService.updateSentence(userIdentifier, sentenceId, request);
-        return ResponseEntity.ok(response);
-    }
-
-    /**
-     * 문장 삭제 - 로그인 불필요, deviceId로 소유자 확인
-     */
     @DeleteMapping("/{sentenceId}")
     public ResponseEntity<Void> deleteSentence(
-            @RequestHeader(value = "X-Device-Id", required = false) String deviceId,
-            @IfLogin(required = false) LoginMemberDto loginMemberDto,
+            @IfLogin LoginMemberDto loginMemberDto,
             @PathVariable("sentenceId") Long sentenceId) {
 
-
-        String userIdentifier = loginMemberDto != null && loginMemberDto.getEmail() != null
-                ? loginMemberDto.getEmail()
-                : (deviceId != null
-                ? deviceId
-                : "anonymous");
-
-        sentenceService.deleteSentence(userIdentifier, sentenceId);
+        sentenceService.deleteSentence(loginMemberDto.getEmail(), sentenceId);
         return ResponseEntity.ok().build();
     }
-
 }

--- a/src/main/java/com/generic/typed/domain/Sentence.java
+++ b/src/main/java/com/generic/typed/domain/Sentence.java
@@ -21,7 +21,6 @@ public class Sentence {
     @JoinColumn(name = "member_id")
     private Member member;
 
-
     @Column(nullable = false, length = 5000)
     private String content;
 
@@ -34,14 +33,13 @@ public class Sentence {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @Column(length = 100)
-    private String deviceId;
-    public Sentence(String content, boolean isPublic, LocalDateTime createdAt, Member member, String deviceId) {
+    // deviceId 필드 제거
+
+    public Sentence(String content, boolean isPublic, LocalDateTime createdAt, Member member) {
         this.content = content;
         this.isPublic = isPublic;
         this.createdAt = createdAt;
         this.member = member;
-        this.deviceId = deviceId;
     }
 
     public void update(String content, boolean isPublic) {

--- a/src/main/java/com/generic/typed/repository/SentenceRepository.java
+++ b/src/main/java/com/generic/typed/repository/SentenceRepository.java
@@ -5,14 +5,10 @@ import com.generic.typed.domain.Sentence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface SentenceRepository extends JpaRepository<Sentence, Long> {
     List<Sentence> findByMember(Member member);
+
     List<Sentence> findByIsPublicTrue();
-
-    List<Sentence> findByDeviceId(String deviceId);
-
-    Optional<Sentence> findByIdAndDeviceId(Long id, String deviceId);
 }
 

--- a/src/main/java/com/generic/typed/service/SentenceService.java
+++ b/src/main/java/com/generic/typed/service/SentenceService.java
@@ -27,133 +27,53 @@ public class SentenceService {
     private final MemberService memberService;
 
     @Transactional
-    public SentenceCreateResponse createSentence(String userIdentifier, SentenceCreateRequest request) {
-        System.out.println("Service - UserIdentifier at start: " + userIdentifier);
-        // 사용자 정보 조회 (로그인한 경우만)
-        Member member = null;
-        if (userIdentifier != null && userIdentifier.contains("@")) {
-            try {
-                // 로그인한 사용자면 조회 시도하되 예외 발생 시 무시
-                member = memberService.findByEmail(userIdentifier);
-            } catch (Exception e) {
-                System.out.println("사용자를 찾을 수 없습니다: " + userIdentifier);
-            }
-        }
+    public SentenceCreateResponse createSentence(String email, SentenceCreateRequest request) {
+        // 요청 검증
+        request.validate();
 
-        // 새 문장 엔티티 생성
+        // 사용자 정보 조회 (로그인 필수)
+        Member member = memberService.findByEmail(email);
+
+        // 새 문장 엔티티 생성 (deviceId 없음)
         Sentence sentence = new Sentence(
                 request.getContent(),
                 request.isPublic(),
                 LocalDateTime.now(),
-                member,
-                member == null ? userIdentifier : null
+                member
         );
-
-        System.out.println("Member: " + member);
-        System.out.println("UserIdentifier: " + userIdentifier);
-        System.out.println("Device ID being set: " + (member == null ? userIdentifier : null));
 
         // 저장
         Sentence savedSentence = sentenceRepository.save(sentence);
 
-        // 응답 생성 (빌더 패턴 사용)
+        // 응답 생성
         return SentenceCreateResponse.from(savedSentence);
     }
 
     @Transactional(readOnly = true)
-    public MySentenceListResponse getMySentences(String userIdentifier) {
-        List<Sentence> sentences;
-
-        if (userIdentifier.contains("@")) {
-            // 이메일이면 회원 정보로 조회
-            try {
-                Member member = memberService.findByEmail(userIdentifier);
-                sentences = sentenceRepository.findByMember(member);
-            } catch (Exception e) {
-                sentences = Collections.emptyList();
-            }
-        } else {
-            // 아니면 디바이스 ID로 조회
-            sentences = sentenceRepository.findByDeviceId(userIdentifier);
-        }
+    public MySentenceListResponse getMySentences(String email) {
+        // 회원 정보로만 조회
+        Member member = memberService.findByEmail(email);
+        List<Sentence> sentences = sentenceRepository.findByMember(member);
 
         return MySentenceListResponse.from(sentences);
     }
+
     @Transactional(readOnly = true)
     public SentenceListResponse getPublicSentences() {
         List<Sentence> sentences = sentenceRepository.findByIsPublicTrue();
         return SentenceListResponse.from(sentences);
     }
 
-
-
     @Transactional
-    public SentenceUpdateResponse updateSentence(String userIdentifier, Long sentenceId, SentenceUpdateRequest request) {
-        // 요청 검증
-        if (userIdentifier == null) {
-            userIdentifier = "anonymous";
+    public void deleteSentence(String email, Long sentenceId) {
+        Member member = memberService.findByEmail(email);
+        Sentence sentence = sentenceRepository.findById(sentenceId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 문장입니다."));
+
+        if (!sentence.getMember().equals(member)) {
+            throw new RuntimeException("해당 문장을 삭제할 권한이 없습니다.");
         }
 
-        Sentence sentence;
-
-        // 사용자 식별자가 이메일인 경우 (로그인한 사용자)
-        if (userIdentifier.contains("@")) {
-            try {
-                Member member = memberService.findByEmail(userIdentifier);
-                sentence = sentenceRepository.findById(sentenceId)
-                        .orElseThrow(() -> new SentenceNotFound());
-
-                // 해당 문장의 소유자가 맞는지 확인
-                if (!sentence.getMember().equals(member)) {
-                    throw new IllegalArgumentException("해당 문장을 수정할 권한이 없습니다.");
-                }
-            } catch (SentenceNotFound e) {
-                throw e;
-            } catch (Exception e) {
-                throw new IllegalArgumentException("문장 수정 중 오류가 발생했습니다.");
-            }
-        } else {
-            // 디바이스 ID로 검색 (비로그인 사용자)
-            sentence = sentenceRepository.findByIdAndDeviceId(sentenceId, userIdentifier)
-                    .orElseThrow(() -> new SentenceNotFound());
-        }
-
-        // 문장 내용 및 공개여부 업데이트
-        sentence.update(request.getContent(), request.isPublic());
-
-        // 응답 생성
-        return SentenceUpdateResponse.from(sentence);
-    }
-
-    @Transactional
-    public void deleteSentence(String userIdentifier, Long sentenceId) {
-        Sentence sentence;
-
-        // 사용자 식별자가 이메일인 경우 (로그인한 사용자)
-        if (userIdentifier.contains("@")) {
-            try {
-                Member member = memberService.findByEmail(userIdentifier);
-                sentence = sentenceRepository.findById(sentenceId)
-                        .orElseThrow(() -> new SentenceNotFound());
-
-                // 해당 문장의 소유자가 맞는지 확인
-                if (!sentence.getMember().equals(member)) {
-                    throw new IllegalArgumentException("해당 문장을 삭제할 권한이 없습니다.");
-                }
-            } catch (SentenceNotFound e) {
-                throw e;
-            } catch (Exception e) {
-                throw new IllegalArgumentException("문장 삭제 중 오류가 발생했습니다.");
-            }
-        } else {
-            // 디바이스 ID로 검색 (비로그인 사용자)
-            sentence = sentenceRepository.findByIdAndDeviceId(sentenceId, userIdentifier)
-                    .orElseThrow(() -> new SentenceNotFound());
-        }
-
-        // 문장 삭제
         sentenceRepository.delete(sentence);
     }
-
-
 }


### PR DESCRIPTION
## 📌 작업 내용 및 특이사항
: 비로그인 사용자 지원을 제거하고 로그인 사용자만 지원하도록 변경
: UUID 기반 디바이스 식별과 로그인 사용자 구분 로직 제거

- 컨트롤러에서 X-Device-Id 헤더 처리 제거
- 서비스 로직에서 디바이스 ID 관련 코드 제거
- 엔티티에서 deviceId 필드 관련 코드 수정
